### PR TITLE
Add backend checking of the user's status

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/CommentsHandler.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/CommentsHandler.java
@@ -21,7 +21,9 @@ import java.util.Map.Entry;
 public class CommentsHandler {
   private DatastoreService datastore;
 
-  public CommentsHandler() { datastore = DatastoreServiceFactory.getDatastoreService(); };
+  public CommentsHandler() {
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  };
 
   public String saveComment(Comment comment) throws BadRequestException {
     Entity commentEntity = new Entity("Comment");
@@ -77,7 +79,8 @@ public class CommentsHandler {
     // use map to build a list of replies for each comment
     Map<String, CommentRepresentationSerializer> commentsMap = new HashMap<>();
     // save each comment to the map
-    comments.forEach(comment -> commentsMap.put(comment.key, new CommentRepresentationSerializer(comment)));
+    comments.forEach(
+      comment -> commentsMap.put(comment.key, new CommentRepresentationSerializer(comment)));
     // update each comment's parent in case there is one
     for (Comment comment : comments) {
       if (comment.replyTo != null) {

--- a/portfolio/src/main/java/com/google/sps/servlets/CommentsHandler.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/CommentsHandler.java
@@ -9,6 +9,8 @@ import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
 import com.google.gson.Gson;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -19,9 +21,7 @@ import java.util.Map.Entry;
 public class CommentsHandler {
   private DatastoreService datastore;
 
-  public CommentsHandler() {
-    datastore = DatastoreServiceFactory.getDatastoreService();
-  };
+  public CommentsHandler() { datastore = DatastoreServiceFactory.getDatastoreService(); };
 
   public String saveComment(Comment comment) throws BadRequestException {
     Entity commentEntity = new Entity("Comment");
@@ -77,8 +77,7 @@ public class CommentsHandler {
     // use map to build a list of replies for each comment
     Map<String, CommentRepresentationSerializer> commentsMap = new HashMap<>();
     // save each comment to the map
-    comments.forEach(
-        comment -> commentsMap.put(comment.key, new CommentRepresentationSerializer(comment)));
+    comments.forEach(comment -> commentsMap.put(comment.key, new CommentRepresentationSerializer(comment)));
     // update each comment's parent in case there is one
     for (Comment comment : comments) {
       if (comment.replyTo != null) {
@@ -90,26 +89,38 @@ public class CommentsHandler {
 
   // deletes the comment with the given key
   // deletes all child comments
-  public void deleteComment(String key) {
-    // Technically if there are replies to this comment I can delete the whole comments thread, I don't know
-    // what is better - to delete them all or to change parent comment to dummy one with "deleted" text
-    // Here I am implementing the first one
-    Map<Key, Entity> commentsMap = new HashMap<>();
-    Query query = new Query("Comment");
-    PreparedQuery results = datastore.prepare(query);
-    for (Entity entity: results.asIterable()) {
-      commentsMap.put(entity.getKey(), entity);
+  public void deleteComment(String key) throws RequestForbiddenException, EntityNotFoundException {
+    // check that user is authenticated and they are an owner of the email
+    UserService userService = UserServiceFactory.getUserService();
+    if (userService.isUserLoggedIn()) {
+      String commentAuthorUsername = (String)(datastore.get(KeyFactory.stringToKey(key)).getProperty("username"));
+      if (commentAuthorUsername != null && commentAuthorUsername.equals(userService.getCurrentUser().getEmail())) {
+        // Technically if there are replies to this comment I can delete the whole comments thread,
+        // I don't know what is better - to delete them all or to change parent comment to dummy one
+        // with "deleted" text Here I am implementing the first one
+        Map<Key, Entity> commentsMap = new HashMap<>();
+        Query query = new Query("Comment");
+        PreparedQuery results = datastore.prepare(query);
+        for (Entity entity : results.asIterable()) {
+          commentsMap.put(entity.getKey(), entity);
+        }
+        deleteThread(KeyFactory.stringToKey(key), commentsMap);
+      } else {
+        throw new RequestForbiddenException("You are not owner of the comment");
+      }
+    } else {
+      throw new RequestForbiddenException("Not authenticated");
     }
-    deleteThread(KeyFactory.stringToKey(key), commentsMap);
   }
-  
+
   // deletes current comment and recursively calls itself to delete all
   // child comments
   private void deleteThread(Key current, Map<Key, Entity> commentsMap) {
     datastore.delete(current);
-    // this can be done faster, presumably in O(thread length) if I store reversed reply keys in the datastore,
-    // then I will only need to run the DFS over the thread. I'm doing this slow version which runs in O(N* thread length)
-    // because it is faster to implement, better approach needs way more time
+    // this can be done faster, presumably in O(thread length) if I store reversed reply keys in the
+    // datastore, then I will only need to run the DFS over the thread. I'm doing this slow version
+    // which runs in O(N* thread length) because it is faster to implement, better approach needs
+    // way more time
     for (Entry<Key, Entity> entry : commentsMap.entrySet()) {
       Object replyToValue = entry.getValue().getProperty("replyTo");
       if (replyToValue != null && replyToValue.equals(KeyFactory.keyToString(current))) {

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
@@ -1,5 +1,10 @@
+/**
+ * This file provides a servlet for deleting comments
+ */
+
 package com.google.sps.servlets;
 
+import com.google.appengine.api.datastore.EntityNotFoundException;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -8,12 +13,23 @@ import javax.servlet.http.HttpServletResponse;
 
 @WebServlet("/delete-data")
 public class DeleteDataServlet extends HttpServlet {
+  private final int BAD_REQUEST = 400;
+  private final int FORBIDDEN = 403;
+  // deletes the comment thread, needs authentication
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     CommentsHandler commentsHandler = new CommentsHandler();
     // get the key of comment that has to be deleted
     String commentKey = request.getParameter("commentKey");
-    commentsHandler.deleteComment(commentKey);
-    response.sendRedirect("./index.html");
+    try {
+      commentsHandler.deleteComment(commentKey);
+      response.sendRedirect("./index.html");
+    } catch (RequestForbiddenException ex) {
+      response.getWriter().println(ex.getMessage());
+      response.setStatus(FORBIDDEN);
+    } catch (EntityNotFoundException ex) {
+      response.getWriter().println("Entity with the given key does not exist");
+      response.setStatus(BAD_REQUEST);
+    }
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/RequestForbiddenException.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/RequestForbiddenException.java
@@ -1,0 +1,14 @@
+/**
+ * This file has class RequestForbiddenException
+ */
+
+package com.google.sps.servlets;
+
+/**
+ * Simple exception to handle cases when user doesn't have enough access
+ */
+public class RequestForbiddenException extends Exception {
+  public RequestForbiddenException(String message) {
+    super(message);
+  }
+}

--- a/portfolio/src/test/java/com/google/sps/servlets/DeleteDataServletTest.java
+++ b/portfolio/src/test/java/com/google/sps/servlets/DeleteDataServletTest.java
@@ -9,6 +9,7 @@ import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.appengine.tools.development.testing.LocalUserServiceTestConfig;
 import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,11 +18,12 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 class DeleteDataServletTest {
   private final int REDIRECT = 302;
+  private final int FORBIDDEN = 403;
   private DeleteDataServlet servlet;
   private MockHttpServletRequest request;
   private MockHttpServletResponse response;
   private final LocalServiceTestHelper helper =
-      new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+      new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig(), new LocalUserServiceTestConfig());
 
   @BeforeEach
   public void setUp() {
@@ -33,9 +35,16 @@ class DeleteDataServletTest {
 
   @Test
   public void testDeleteCommentsSuccess() {
+    // log the user in
+    String testEmail = "test@example.com";
+    helper.setEnvIsLoggedIn(true);
+    helper.setEnvEmail(testEmail);
+    helper.setEnvAuthDomain("envAuthDomain");
+
+    // create comment entities
     DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
     Entity commentEntity = new Entity("Comment");
-    commentEntity.setProperty("username", "username");
+    commentEntity.setProperty("username", testEmail);
     commentEntity.setProperty("text", "text");
     ds.put(commentEntity);
     Entity commentEntityReply = new Entity("Comment");
@@ -49,17 +58,72 @@ class DeleteDataServletTest {
     otherComment.setProperty("username", "usernameOther");
     otherComment.setProperty("text", "textOther");
     ds.put(otherComment);
+
     try {
       servlet.doPost(request, response);
       assertEquals(response.getStatus(), REDIRECT);
       // one must left
       PreparedQuery results = ds.prepare(new Query("Comment"));
       assertEquals(1, results.countEntities());
-      for (Entity entity: results.asIterable()) {
+      for (Entity entity : results.asIterable()) {
         assertEquals(entity.getProperty("username"), "usernameOther");
         assertEquals(entity.getProperty("text"), "textOther");
       }
-    } catch(IOException ex) {
+    } catch (IOException ex) {
+      System.out.println(ex.getMessage());
+    }
+  }
+
+  @Test
+  public void testDeleteCommentsFailNoAuth() {
+    // this test doesn't log the user in
+    DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
+    Entity commentEntity = new Entity("Comment");
+    commentEntity.setProperty("username", "username");
+    commentEntity.setProperty("text", "text");
+    ds.put(commentEntity);
+    request.addParameter("commentKey", KeyFactory.keyToString(commentEntity.getKey()));
+    try {
+      servlet.doPost(request, response);
+      assertEquals(response.getStatus(), FORBIDDEN);
+      // one must left, it should not be deleted
+      PreparedQuery results = ds.prepare(new Query("Comment"));
+      assertEquals(1, results.countEntities());
+      for (Entity entity : results.asIterable()) {
+        assertEquals(entity.getProperty("username"), "username");
+        assertEquals(entity.getProperty("text"), "text");
+      }
+    } catch (IOException ex) {
+      System.out.println(ex.getMessage());
+    }
+  }
+
+  @Test
+  public void testDeleteCommentsFailWrongAuth() {
+    // log the user in
+    String testEmail = "test@example.com";
+    helper.setEnvIsLoggedIn(true);
+    helper.setEnvEmail(testEmail);
+    helper.setEnvAuthDomain("envAuthDomain");
+    // in case user attempts to delete comments of another user
+    DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
+    Entity commentEntity = new Entity("Comment");
+    // use another email here, not the user's who is logged in
+    commentEntity.setProperty("username", "username");
+    commentEntity.setProperty("text", "text");
+    ds.put(commentEntity);
+    request.addParameter("commentKey", KeyFactory.keyToString(commentEntity.getKey()));
+    try {
+      servlet.doPost(request, response);
+      assertEquals(response.getStatus(), FORBIDDEN);
+      // one must left, it should not be deleted
+      PreparedQuery results = ds.prepare(new Query("Comment"));
+      assertEquals(1, results.countEntities());
+      for (Entity entity : results.asIterable()) {
+        assertEquals(entity.getProperty("username"), "username");
+        assertEquals(entity.getProperty("text"), "text");
+      }
+    } catch (IOException ex) {
       System.out.println(ex.getMessage());
     }
   }


### PR DESCRIPTION
Creating a separate PR for the delete auth handling, doing this to keep my PRs smaller. This is the feature that I forgot to add yesterday, @harry-7 so Im fixing it here. I m sorry I forgot to add that in previous one